### PR TITLE
arreglados estilos de los botones en las cards de producto

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1290,3 +1290,39 @@ h3 {
   letter-spacing: 0.5px;
   box-shadow: 0 2px 8px rgba(194, 90, 0, 0.07);
 }
+
+/* Unifica el alto de los botones de las cards de producto y ajusta el tamaño del icono del carrito */
+.btn-add-cart {
+  min-height: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+}
+.btn-add-cart i {
+  font-size: 1.1em;
+  margin-right: 0.5em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Asegura que el botón de ver detalle tenga el mismo alto */
+.btn-detail {
+  min-height: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+}
+.btn-detail i {
+  font-size: 1.1em;
+  margin-right: 0.5em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/js/productos.js
+++ b/src/js/productos.js
@@ -93,9 +93,11 @@ fetch("../assets/data/products.json")
           actualizarContadorCarrito();
         }
         // Feedback visual
-        this.textContent = "¡Añadido!";
+        this.innerHTML = "¡Añadido!";
+        this.disabled = true;
         setTimeout(() => {
-          this.textContent = "Añadir al carrito";
+          this.innerHTML = '<i class="bi bi-cart-plus me-2"></i>Añadir al carrito';
+          this.disabled = false;
         }, 1000);
       });
     });


### PR DESCRIPTION
Arreglado el estilo de los botones en las cards de producto. Ahora son iguales antes y después de añadir el producto, mostrándose mensaje de añadido como antes